### PR TITLE
Added boundedrand_r, very useful for secure random ints

### DIFF
--- a/pypcg.py
+++ b/pypcg.py
@@ -79,6 +79,9 @@ class PCG32(Random):
   def random(self):
     return float(c_interface.pcg32_random_r(self._rng_state))/float(2**32-1)
 
+  def boundedrand_r(self, bound):
+    return int(c_interface.pcg32_boundedrand_r(self._rng_state, bound))
+
   def seed(self, a=None, seq=DEFAULT_SEQUENCE, version=2):
     #TODO support version 2 so we can support python3
     if type(a) != int:


### PR DESCRIPTION
Hi,

If you could pull this that would be great, it's very hard to get secure random integers and doing something like `round(pcg.random()) % n` is not secure. The function `boundedrand_r` is a much more secure and reliable method for generating random ints using PCG.

Thanks,
Jon
